### PR TITLE
Fix build error caused by undefined 'vessels'

### DIFF
--- a/src/app/api/ships/route.ts
+++ b/src/app/api/ships/route.ts
@@ -312,5 +312,5 @@ async function getOSINTNavalPositions(): Promise<NavalVessel[]> {
     },
   ];
 
-  return [...knownDeployments, ...vessels];
+  return knownDeployments;
 }


### PR DESCRIPTION
This fixes a build error in route.ts where 'vessels' is referenced but not defined.

Removed the reference to prevent build failure.